### PR TITLE
fix: updated github actions to use ghcr instead of docker hub

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -22,11 +22,12 @@ jobs:
           fetch-depth: 0
           ref: ${{inputs.ref}}
 
-      - name: Login to Docker Hub
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -59,7 +60,7 @@ jobs:
           {
             echo 'DOCKER_IMAGE_TAGS<<EOF'
             for tag in ${TAGS}; do
-            echo "${{ secrets.DOCKERHUB_USERNAME }}/stremio-addon-debrid-search:${tag}"
+            echo "ghcr.io/${{ github.repository_owner }}/stremio-addon-debrid-search:${tag}"
             done
             echo EOF
           } >> "${GITHUB_ENV}"


### PR DESCRIPTION
Updated the Docker build and push workflow to use GitHub Container Registry (ghcr.io) instead of Docker Hub.

No secrets required.