### PR TITLE
Fix Docker latest tag

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -45,6 +45,8 @@ jobs:
             TAGS="${INPUT_REF}"
             if [[ "$(git rev-parse origin/main)" = "$(git rev-parse "${INPUT_REF}")" ]]; then
               TAGS="${TAGS} latest"
+            elif [[ "$(git describe --tags --abbrev=0 origin/main)" = "${INPUT_REF}" ]]; then
+              TAGS="${TAGS} latest"
             fi
             ;;
           *)
@@ -57,10 +59,13 @@ jobs:
             exit 1
           fi
 
+          REPO_OWNER="${{ github.repository_owner }}"
+          REPO_OWNER_LOWER="${REPO_OWNER,,}"
+
           {
             echo 'DOCKER_IMAGE_TAGS<<EOF'
             for tag in ${TAGS}; do
-            echo "ghcr.io/${{ github.repository_owner }}/stremio-addon-debrid-search:${tag}"
+            echo "ghcr.io/${REPO_OWNER_LOWER}/stremio-addon-debrid-search:${tag}"
             done
             echo EOF
           } >> "${GITHUB_ENV}"


### PR DESCRIPTION
This PR resolves the "latest" tag not being applied to built images that are the latest. 
<img width="1324" height="793" alt="image" src="https://github.com/user-attachments/assets/497a9499-0ba0-4657-8b28-c1d1ecd11fb5" />
