### PR TITLE
fix: landing template now works as banner without hiding content

### DIFF
--- a/lib/util/landingTemplate.js
+++ b/lib/util/landingTemplate.js
@@ -26,13 +26,10 @@ html {
 }
 
 body {
-    display: flex;
-    align-items: center;
-    justify-content: center;
 	font-family: 'Open Sans', Arial, sans-serif;
 	color: #ccd6f6;
     line-height: 1.5;
-    padding: 1em; /* Add some padding for small screens */
+    padding: 2em 1em; /* Top padding for banner effect */
 }
 
 #addon {
@@ -325,21 +322,21 @@ button:active {
         display: none !important;
     }
 
-    /* Fit everything in viewport - NO SCROLLING */
+    /* Allow scrolling for mobile */
     body {
-        padding: 0;
-        overflow: hidden;
-        height: 100vh;
+        padding: 1em 0;
+        overflow-y: auto;
+        min-height: 100vh;
     }
 
     #addon {
         width: 100vw;
-        height: 100vh;
+        min-height: auto;
         display: flex;
         flex-direction: column;
         padding: 0.5em;
         margin: 0;
-        overflow: hidden;
+        overflow-y: auto;
         box-sizing: border-box;
     }
 


### PR DESCRIPTION
- Removed flexbox centering from body that was hiding overflow content
- Changed mobile viewport to allow scrolling (overflow-y: auto)
- Fixed mobile #addon to use min-height: auto instead of fixed height
- Template now blends as a banner on top instead of centered modal