### PR TITLE
feat: use TorBox checkcached API with file info for pack inspection

### DIFF
--- a/lib/torbox.js
+++ b/lib/torbox.js
@@ -164,7 +164,15 @@ async function searchTorboxTorrents(apiKey, type, id, userConfig = {}) {
         console.timeEnd(totalSearchTimer);
 
         // Combine live and cached scraper results
-        scraperResults = [...scraperResults, ...cachedScraperResults];
+        // Reconstruct episodeFileHint from postgres data spread (filePath/fileBytes are stored
+        // flat in the data column but formatExternalResult expects nested episodeFileHint)
+        const fixedCachedResults = cachedScraperResults.map(r => {
+            if (r.filePath && !r.episodeFileHint) {
+                return { ...r, episodeFileHint: { filePath: r.filePath, fileBytes: r.fileBytes } };
+            }
+            return r;
+        });
+        scraperResults = [...scraperResults, ...fixedCachedResults];
         
         if (type === 'series' && episodeInfo) {
             const originalCount = personalFiles.length;
@@ -446,14 +454,12 @@ async function combineAndMarkResults(apiKey, personalFiles, externalSources, epi
     } catch (error) {
         console.error(`[TB SQLCACHE] Error checking SQLite cache: ${error.message}`);
     }
-    let cacheFileInfo = new Map();
     const remaining = hashesToCheck.filter(h => !cachedHashes.has(h));
     if (remaining.length > 0) {
         const remote = await checkTorboxCache(apiKey, remaining);
         remote.cachedHashes.forEach(h => cachedHashes.add(h));
-        cacheFileInfo = remote.fileInfo;
     }
-    console.log(`[TB] Found ${cachedHashes.size} cached torrents from ${hashesToCheck.length} unique candidates (${cacheFileInfo.size} with file info).`);
+    console.log(`[TB] Found ${cachedHashes.size} cached torrents from ${hashesToCheck.length} unique candidates.`);
 
         const cachedTorrents = franchiseFiltered.filter(t => {
             const ih = (t.InfoHash || t.infoHash || t.hash || '').toString().toLowerCase();
@@ -481,7 +487,7 @@ async function combineAndMarkResults(apiKey, personalFiles, externalSources, epi
     }
     console.log(`[TB DEBUG] Divided cached torrents into ${cachedSingleFiles.length} single files and ${cachedPacks.length} packs.`);
     
-    const packResults = await inspectCachedPacks(apiKey, cachedPacks, episodeInfo, cacheFileInfo);
+    const packResults = await inspectCachedPacks(apiKey, cachedPacks, episodeInfo);
     console.log(`[TB DEBUG] Pack inspection found ${packResults.length} matching episode files.`);
 
     // --- Final Combination ---
@@ -547,31 +553,32 @@ async function combineAndMarkResults(apiKey, personalFiles, externalSources, epi
     return finalUniqueResults;
 }
 
-async function inspectCachedPacks(apiKey, packs, episodeInfo, cacheFileInfo = new Map()) {
+async function inspectCachedPacks(apiKey, packs, episodeInfo) {
     if (!episodeInfo || packs.length === 0) {
         return [];
     }
     const { season, episode } = episodeInfo;
     const results = [];
-    console.log(`[${LOG_PREFIX} PACK INSPECT] Starting inspection for ${packs.length} cached packs (${cacheFileInfo.size} have pre-fetched file info).`);
+    console.log(`[${LOG_PREFIX} PACK INSPECT] Starting inspection for ${packs.length} cached packs.`);
 
     for (const pack of packs) {
         try {
             const packHash = (pack.InfoHash || pack.infoHash || pack.hash || '').toString().toLowerCase();
             console.log(`[${LOG_PREFIX} PACK INSPECT] Inspecting pack: ${pack.Title}`);
 
-            // Try file info from cache check first (saves an API call per pack)
+            // checkcached doesn't return file info, so we need to add the torrent
+            // to get its file list. For cached torrents this is instant and free.
             let files = null;
-            const cachedInfo = cacheFileInfo.get(packHash);
-            if (cachedInfo && Array.isArray(cachedInfo.files)) {
-                files = cachedInfo.files;
-                console.log(`[${LOG_PREFIX} PACK INSPECT] Using file info from cache check (${files.length} files)`);
-            } else {
-                // Fallback to separate API call
-                const torrentInfo = await getTorrentInfoFromCache(apiKey, packHash);
-                if (torrentInfo && Array.isArray(torrentInfo.files)) {
-                    files = torrentInfo.files;
+            const magnetLink = `magnet:?xt=urn:btih:${packHash}`;
+            try {
+                await addToTorbox(apiKey, magnetLink);
+                const readyTorrent = await waitForTorrentReady(apiKey, packHash, 15000, 2000);
+                if (readyTorrent && Array.isArray(readyTorrent.files)) {
+                    files = readyTorrent.files;
+                    console.log(`[${LOG_PREFIX} PACK INSPECT] Got ${files.length} files via createtorrent+mylist`);
                 }
+            } catch (err) {
+                console.warn(`[${LOG_PREFIX} PACK INSPECT] Failed to get files for pack ${packHash}: ${err.message}`);
             }
 
             if (!files) {
@@ -610,7 +617,7 @@ async function inspectCachedPacks(apiKey, packs, episodeInfo, cacheFileInfo = ne
 }
 
 async function checkTorboxCache(apiKey, hashes) {
-    const empty = { cachedHashes: new Set(), fileInfo: new Map() };
+    const empty = { cachedHashes: new Set() };
     if (!hashes || hashes.length === 0) return empty;
     const url = `${TB_BASE_URL}/api/torrents/checkcached`;
     const headers = getHeaders(apiKey);
@@ -633,20 +640,15 @@ async function checkTorboxCache(apiKey, hashes) {
         );
 
         if (response.data?.success && typeof response.data.data === 'object') {
-            // TorBox API returns an object keyed by hash with name, size, hash, and files array
+            // checkcached returns { hash: { name, size, hash } } — no file info
             const cachedHashes = new Set();
-            const fileInfo = new Map();
 
-            for (const [hash, info] of Object.entries(response.data.data)) {
-                const lowerHash = hash.toLowerCase();
-                cachedHashes.add(lowerHash);
-                if (info && Array.isArray(info.files)) {
-                    fileInfo.set(lowerHash, info);
-                }
+            for (const hash of Object.keys(response.data.data)) {
+                cachedHashes.add(hash.toLowerCase());
             }
 
-            console.log(`[${LOG_PREFIX}] TorBox API returned ${cachedHashes.size} cached hashes (${fileInfo.size} with file info)`);
-            return { cachedHashes, fileInfo };
+            console.log(`[${LOG_PREFIX}] TorBox API returned ${cachedHashes.size} cached hashes`);
+            return { cachedHashes };
         }
         return empty;
     } catch (error) {
@@ -831,26 +833,6 @@ async function getTorrentList(apiKey, bypassCache = false) {
     }
 }
 
-async function getTorrentInfoFromCache(apiKey, hash) {
-    const url = `${TB_BASE_URL}/api/torrents/checkcached`;
-    const headers = getHeaders(apiKey);
-    const lowerHash = hash.toLowerCase();
-    try {
-        const response = await torboxRequest(
-            () => axios.post(url, { hashes: lowerHash, format: 'object' }, debridProxyManager.getAxiosConfig('torbox', { headers, timeout: TIMEOUT })),
-            `torrent info ${hash?.substring(0, 8) || ''}`.trim()
-        );
-        if (response.data?.success && typeof response.data.data === 'object') {
-            const info = response.data.data[lowerHash];
-            if (info && Array.isArray(info.files)) {
-                return info;
-            }
-        }
-    } catch (error) {
-        console.error(`[${LOG_PREFIX}] Failed to get torrent info for ${hash}: ${error.message}`);
-    }
-    return null;
-}
 
 async function processPersonalHistory(torrentsFromApi, apiKey) {
     const processedFiles = torrentsFromApi.map(torrent => {


### PR DESCRIPTION
Update TorBox integration to use the /api/torrents/checkcached endpoint with format=object, which returns file lists inline. This eliminates separate /api/torrents/torrentinfo calls during pack inspection by reusing file info from the cache check response.